### PR TITLE
Fix for bug https://rt.cpan.org/Public/Bug/Display.html?id=84546

### DIFF
--- a/perl/modules/XML-SemanaticDiff/Changes
+++ b/perl/modules/XML-SemanaticDiff/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl module XML::SemanticDiff
 
+1.0006 2017-09-26
+    - Fixed a bug that was causing the code to treat
+      <element>0</element> the same as <element></element>
+
 1.0005 2017-02-06
     - Convert the distribution to use git, GitHub, and Dist-Zilla.
     - Correct some spelling errors and add more tests.

--- a/perl/modules/XML-SemanaticDiff/Changes
+++ b/perl/modules/XML-SemanaticDiff/Changes
@@ -1,8 +1,9 @@
 Revision history for Perl module XML::SemanticDiff
 
 1.0006 2017-09-26
-    - Fixed a bug that was causing the code to treat
-      <element>0</element> the same as <element></element>
+    - Fixed bug: https://rt.cpan.org/Public/Bug/Display.html?id=84546 
+      where the code was failing to find the difference in this scenario
+      Before: <element>0</element> After: <element></element>
 
 1.0005 2017-02-06
     - Convert the distribution to use git, GitHub, and Dist-Zilla.

--- a/perl/modules/XML-SemanaticDiff/dist.ini
+++ b/perl/modules/XML-SemanaticDiff/dist.ini
@@ -3,7 +3,7 @@ author  = Shlomi Fish <shlomif@cpan.org>
 license = Perl_5
 copyright_holder = Kim Hampton
 copyright_year   = 2001
-version = 1.0005
+version = 1.0006
 
 [@Filter]
 -bundle = @SHLOMIF

--- a/perl/modules/XML-SemanaticDiff/lib/XML/SemanticDiff.pm
+++ b/perl/modules/XML-SemanaticDiff/lib/XML/SemanticDiff.pm
@@ -361,14 +361,10 @@ sub EndTag {
 #    $ctx->add("$text");
 #    $self->doc()->{"$test_context"}->{TextChecksum} = $ctx->b64digest;
 
-    if (defined $text) {
-        $self->doc()->{"$test_context"}->{TextChecksum} = md5_base64(encode_utf8("$text"));
-    } else {
-        # In XML, a null value and an empty string should be treaded the same.
-        # Therefore, when the element is undef, we should set the TextChecksum to the same
-        # as an empty string.
-        $self->doc()->{"$test_context"}->{TextChecksum} = md5_base64(encode_utf8(""));
-    }
+    # In XML, a null(undef) value and an empty string should be treaded the same.
+    # Therefore, when the element is undef, we should set the TextChecksum to the same
+    # as an empty string.
+    $self->doc()->{"$test_context"}->{TextChecksum} = (defined $text) ? md5_base64(encode_utf8("$text")) :  md5_base64(encode_utf8(""));
 
     if ($self->opts()->{keepdata}) {
         $self->doc()->{"$test_context"}->{CData} = $text;

--- a/perl/modules/XML-SemanaticDiff/lib/XML/SemanticDiff/BasicHandler.pm
+++ b/perl/modules/XML-SemanaticDiff/lib/XML/SemanticDiff/BasicHandler.pm
@@ -3,7 +3,7 @@ package XML::SemanticDiff::BasicHandler;
 use strict;
 use warnings;
 
-our $VERSION = '1.0005';
+our $VERSION = '1.0006';
 
 sub new {
     my ($proto, %args) = @_;

--- a/perl/modules/XML-SemanaticDiff/t/16zero_to_empty_str_cmp.t
+++ b/perl/modules/XML-SemanaticDiff/t/16zero_to_empty_str_cmp.t
@@ -1,0 +1,125 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use Test::More tests => 18;
+
+use XML::SemanticDiff;
+
+my $xml_attr_0 = <<'EOX';
+<?xml version="1.0"?>
+<root>
+<el1 el1attr="0"/>
+</root>
+EOX
+
+my $xml_attr_empty_string = <<'EOX';
+<?xml version="1.0"?>
+<root>
+<el1 el1attr=""/>
+</root>
+EOX
+
+my $xml_attr_missing = <<'EOX';
+<?xml version="1.0"?>
+<root>
+<el1 />
+</root>
+EOX
+
+my $xml_elem_0 = <<'EOX';
+<?xml version="1.0"?>
+<root>
+<el2>0</el2>
+</root>
+EOX
+
+my $xml_elem_empty_string = <<'EOX';
+<?xml version="1.0"?>
+<root>
+<el2></el2>
+</root>
+EOX
+
+my $xml_elem_undef = <<'EOX';
+<?xml version="1.0"?>
+<root>
+<el2 />
+</root>
+EOX
+
+my ($diff, @results);
+
+# TEST
+$diff = XML::SemanticDiff->new(keepdata => 1, keeplinenums => 1);
+@results = $diff->compare($xml_attr_0, $xml_attr_empty_string);
+is (scalar(@results), 1,
+    "Difference found between 0 and empty string in attr"
+);
+
+# TEST
+is ($results[0]->{old_value}, 0, "check old value 0");
+# TEST
+is ($results[0]->{new_value}, '', "check new value empty_string");
+
+# TEST
+$diff = XML::SemanticDiff->new(keepdata => 1, keeplinenums => 1);
+@results = $diff->compare($xml_attr_0, $xml_attr_missing);
+is (scalar(@results), 1,
+    "Difference found between 0 and missing attr"
+);
+
+# TEST
+is ($results[0]->{old_value}, 0, "check old value 0");
+# TEST
+is ($results[0]->{new_value}, undef, "check new value undef");
+
+# TEST
+$diff = XML::SemanticDiff->new(keepdata => 1, keeplinenums => 1);
+@results = $diff->compare($xml_elem_0, $xml_elem_empty_string);
+is (scalar(@results), 1,
+    "Difference found between 0 and empty string in elem(<el></el>)"
+);
+
+# TEST
+is ($results[0]->{old_value}, 0, "check old value 0");
+# TEST
+is ($results[0]->{new_value}, undef, "check new value undef");
+
+# TEST
+$diff = XML::SemanticDiff->new(keepdata => 1, keeplinenums => 1);
+@results = $diff->compare($xml_elem_0, $xml_elem_undef);
+is (scalar(@results), 1,
+    "Difference found between 0 and empty string in elem(<el />)"
+);
+
+# TEST
+is ($results[0]->{old_value}, 0, "check old value 0");
+# TEST
+is ($results[0]->{new_value}, undef, "check new value undef");
+
+# TEST
+@results = $diff->compare($xml_attr_0, $xml_attr_0);
+ok ((!@results), "Identical XMLs with attrs 0 generate identical results");
+
+# TEST
+@results = $diff->compare($xml_attr_empty_string, $xml_attr_empty_string);
+ok ((!@results), "Identical XMLs with attrs empty_string generate identical results");
+
+# TEST
+@results = $diff->compare($xml_attr_missing, $xml_attr_missing);
+ok ((!@results), "Identical XMLs with attrs missing generate identical results");
+
+# TEST
+@results = $diff->compare($xml_elem_0, $xml_elem_0);
+ok ((!@results), "Identical XMLs with elem 0 generate identical results");
+
+# TEST
+@results = $diff->compare($xml_elem_empty_string, $xml_elem_empty_string);
+ok ((!@results), "Identical XMLs with elem empty_string generate identical results");
+
+# TEST
+@results = $diff->compare($xml_elem_undef, $xml_elem_undef);
+ok ((!@results), "Identical XMLs with elem undef generate identical results");
+
+


### PR DESCRIPTION
Hi Shlomi,
There is an old outstanding bug where this code treats the following as the same:

```
<element>0</element>
and
<element></element>
```

I believe this behavior is incorrect and the code should report those two as different.  I have updated the code so that it will identify this difference.

In version 1.005 (before the changes) I see the following in the debugger:

```
DB<16> use XML::SemanticDiff
DB<17> $fos_xml = '<root><element>0</element></root>'      
DB<18> $rest_xml = '<root><element></element></root>'
DB<19> $diff = XML::SemanticDiff->new(keepdata => 1, keeplinenums => 1); 
DB<20> x @changes = $diff->compare($rest_xml, $fos_xml)
  empty array
```
In version 1.006 (with changes in this pull request)  I see the following in the debugger:
```
DB<21> use XML::SemanticDiff
DB<22> $fos_xml = '<root><element>0</element></root>'
DB<23> $rest_xml = '<root><element></element></root>'
DB<24> $diff = XML::SemanticDiff->new(keepdata => 1, keeplinenums => 1);
DB<25> x @changes = $diff->compare($rest_xml, $fos_xml)
0  HASH(0x41eb8f0)
'context' => '/root[1]/element[1]'
'endline' => 1
'message' => 'Character differences in element \'element\'.'
'new_value' => 0
'old_value' => undef
'startline' => 1
```
Let me know if you have any questions on the changes I am proposing.

Thanks