### PR TITLE
Add support for CI testing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,63 @@
+environment:
+    install_berry_perl: "cmd /C git clone https://github.com/stevieb9/berrybrew && cd berrybrew/bin && berrybrew.exe install %version% && berrybrew.exe switch %version%"
+    install_active_perl: "cmd /C choco install activeperl --version %version%"
+
+    matrix:
+      - install_perl: "%install_berry_perl%"
+        version: "5.26.0_64"
+      - install_perl: "%install_berry_perl%"
+        version: "5.24.2_64"
+      - install_perl: "%install_berry_perl%"
+        version: "5.22.3_64"
+      - install_perl: "%install_berry_perl%"
+        version: "5.20.3_64"
+      - install_perl: "%install_berry_perl%"
+        version: "5.18.4_64"
+      - install_perl: "%install_berry_perl%"
+        version: "5.16.3_64"
+      - install_perl: "%install_berry_perl%"
+        version: "5.14.4_64"
+      - install_perl: "%install_berry_perl%"
+        version: "5.12.3_32"
+      - install_perl: "%install_active_perl%"
+        version: "5.24.1.2402"
+
+install:
+  # Install perl
+  - cmd: "%install_perl%"
+  # Make sure we are in project root
+  - cmd: "cd %APPVEYOR_BUILD_FOLDER%"
+  # Set path for berrybrew
+  - SET PATH=C:\berrybrew\%version%\c\bin;C:\berrybrew\%version%\perl\site\bin;C:\berrybrew\%version%\perl\bin;%PATH%
+  # ActivePerl does not include cpanminus
+  - cpan      App::cpanminus
+  - cpanm -nq PerlIO::utf8_strict
+  - cpanm -nq Mixin::Linewise::Readers
+  - cpanm -nq Params::Validate
+  - cpanm -nq Getopt::Long::Descriptive
+  - cpanm -nq Log::Dispatch::Output Software::LicenseUtils Config::MVP::Reader::INI Config::MVP::Assembler Text::Template Data::Section App::Cmd::Tester Log::Dispatchouli MooseX::Types::Perl String::Formatter MooseX::SetOnce CPAN::Uploader Config::MVP::Section Perl::PrereqScanner App::Cmd::Setup Config::MVP::Reader Software::License Config::MVP::Reader::Findable::ByExtension Config::MVP::Reader::Finder Pod::Eventual Mixin::Linewise::Readers Config::MVP::Assembler::WithBundles App::Cmd::Command::version Config::INI::Reader App::Cmd::Tester::CaptureExternal Term::Encoding
+  - cpanm -nq Module::Build
+  - cpanm -nq Dist::Zilla
+  # Module files for this distribution are not in root
+  - cmd: "cd perl/modules/XML-SemanticDiff"
+  - dzil authordeps | cpanm -nq
+  - dzil listdeps   | cpanm -nq
+  - cpanm -nq Test::EOL Test::NoTabs Test::Pod Test::Pod::Coverage Pod::Coverage::TrustPod
+
+build: off
+
+test_script:
+  - dzil test
+
+shallow_clone: true
+
+matrix:
+  allow_failures:
+    - install_perl: "%install_berry_perl%"
+      version: "5.16.3_64"
+    - install_perl: "%install_berry_perl%"
+      version: "5.14.4_64"
+    - install_perl: "%install_berry_perl%"
+      version: "5.12.3_32"
+    - install_perl: "%install_active_perl%"
+      version: "5.24.1.2402"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+---
+sudo: false
+language: perl
+perl:
+  - blead
+  - dev
+  - '5.26'
+  - '5.24'
+  - '5.22'
+  - '5.20'
+  - '5.18'
+  - '5.16'
+  - '5.14'
+  - '5.12'
+matrix:
+  allow_failures:
+    - perl: blead
+env:
+  global:
+    - RELEASE_TESTING=1
+    - AUTHOR_TESTING=1
+before_install:
+  - cd perl/modules/XML-SemanticDiff
+  - eval $(curl https://travis-perl.github.io/init) --auto

--- a/perl/modules/XML-SemanticDiff/dist.ini
+++ b/perl/modules/XML-SemanticDiff/dist.ini
@@ -5,6 +5,8 @@ copyright_holder = Kim Hampton
 copyright_year   = 2001
 version = 1.0006
 
+; authordep Pod::Weaver::Section::Support
+
 [@Filter]
 -bundle = @SHLOMIF
 -remove = License


### PR DESCRIPTION
This patch adds configuration files for Travis and AppVeyor (and should close #1 and #2).

It also includes a small change in `dist.ini` to make it possible to build the module (6ccd631).

The Travis setup uses the [Travis Perl helpers](https://github.com/travis-perl/helpers) to test versions 5.12 and up, including 5.26 as well as "blead" and "dev" (allowing failures on "blead").

The AppVeyor configuration is mostly copied from [that of Alien::Build](https://github.com/Perl5-Alien/Alien-Build/blob/master/.appveyor.yml), which means that it also copies all of its idiosyncrasies (in particular, long lists of packages that need to be installed manually for some reason, etc). Here you can see [the results of the latest build of my fork](https://ci.appveyor.com/project/jjatria/perl-xml-semanticdiff).

It tests Strawberry Perl versions 5.12 and up, including 5.26. All of them are tested on 64 bit, except 5.12.4, which is only available on 32 bit. ActiveState Perl 5.24 (the latest at the time) is also tested. 

Acknowledgements go to @plicease and @lancew for their work on the original AppVeyor config.
